### PR TITLE
[Feat] Tag 컴포넌트 생성

### DIFF
--- a/beta-reader/app/globals.css
+++ b/beta-reader/app/globals.css
@@ -11,16 +11,16 @@
   --color-primary-600: #111d92;
 
   --color-secondary-white: #ffffff;
-  --color-secondary-black: #000000;
-  --color-secondary-100: #f5f5f5;
-  --color-secondary-200: #e5e5e5;
-  --color-secondary-300: #d4d4d4;
-  --color-secondary-400: #a3a3a3;
-  --color-secondary-500: #737373;
-  --color-secondary-600: #525252;
-  --color-secondary-700: #404040;
-  --color-secondary-800: #262626;
-  --color-secondary-900: #171717;
+  --color-secondary-black: #121212;
+  --color-secondary-100: ##d9deee;
+  --color-secondary-200: ##bfc3d3;
+  --color-secondary-300: ##989daf;
+  --color-secondary-400: ##7b8091;
+  --color-secondary-500: #606575;
+  --color-secondary-600: #4a4e5b;
+  --color-secondary-700: #3a3d46;
+  --color-secondary-800: #2c2d34;
+  --color-secondary-900: #1e1f24;
 
   --color-warning-100: #fe9189;
   --color-warning-200: #ff564a;

--- a/beta-reader/public/assets/CloseIcon.tsx
+++ b/beta-reader/public/assets/CloseIcon.tsx
@@ -1,0 +1,19 @@
+export const CloseIcon = () => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="1rem"
+      height="1rem"
+      viewBox="0 0 16 16"
+      fill="none"
+    >
+      <path
+        d="M12 12L8 8M8 8L4 4M8 8L12 4M8 8L4 12"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};

--- a/beta-reader/public/assets/index.ts
+++ b/beta-reader/public/assets/index.ts
@@ -1,1 +1,2 @@
 export * from "./checkIcon";
+export * from "./CloseIcon";

--- a/beta-reader/src/shared/ui/Tag.stories.tsx
+++ b/beta-reader/src/shared/ui/Tag.stories.tsx
@@ -1,0 +1,79 @@
+import { Tag } from "./Tag";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof Tag> = {
+  title: "Shared/Tag",
+  component: Tag,
+  parameters: {
+    layout: "centered"
+  },
+
+  argTypes: {
+    rounded: {
+      control: {
+        type: "boolean"
+      }
+    },
+    className: {
+      control: {
+        type: "text"
+      }
+    },
+    onClick: {
+      action: "clicked"
+    }
+  },
+
+  tags: ["autodocs"]
+};
+
+export default meta;
+type Story = StoryObj<typeof Tag>;
+
+export const Default: Story = {
+  args: {
+    children: "태그"
+  }
+};
+
+export const Rounded: Story = {
+  args: {
+    children: "둥근 태그",
+    rounded: true
+  }
+};
+
+export const WithOnClick: Story = {
+  args: {
+    children: "클릭 가능한 태그",
+    onClick: () => alert("태그가 클릭되었습니다")
+  }
+};
+
+export const RoundedWithOnClick: Story = {
+  args: {
+    children: "둥근 클릭 가능한 태그",
+    rounded: true,
+    onClick: () => alert("둥근 태그가 클릭되었습니다")
+  }
+};
+
+export const CustomClassName: Story = {
+  args: {
+    children: "커스텀 클래스",
+    className: "border-2 border-primary-500"
+  }
+};
+
+export const Multiple: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <Tag>태그 1</Tag>
+      <Tag rounded>태그 2</Tag>
+      <Tag onClick={() => console.log("clicked")}>태그 3</Tag>
+      <Tag rounded onClick={() => console.log("clicked")}>
+        태그 4
+      </Tag>
+    </div>
+  )
+};

--- a/beta-reader/src/shared/ui/Tag.tsx
+++ b/beta-reader/src/shared/ui/Tag.tsx
@@ -1,0 +1,48 @@
+import { CloseIcon } from "@/public/assets";
+
+interface TagProps {
+  rounded?: boolean;
+  className?: string;
+  children?: React.ReactNode;
+  onClick?: () => void;
+}
+
+const paddingClassName = "px-3 py-1.5";
+const backgrondClassName = "bg-secondary-700 hover:bg-secondary-500";
+const textClassName = "text-secondary-white text-caption-1-medium";
+
+const baseClassName = `
+  ${paddingClassName} 
+  ${backgrondClassName} 
+  ${textClassName}
+  flex justify-center items-center gap-1
+`;
+
+export const Tag: React.FC<TagProps> = ({
+  rounded,
+  className,
+  children,
+  onClick
+}) => {
+  const roundClassName = rounded ? "rounded-full" : "rounded-lg";
+
+  if (onClick) {
+    return (
+      <button
+        className={`${baseClassName} ${roundClassName} ${className} border-secondary-600 hover:border-secondary-500 cursor-pointer border`}
+        onClick={onClick}
+        type="button"
+        aria-label="tag"
+      >
+        {children}
+        <CloseIcon />
+      </button>
+    );
+  }
+
+  return (
+    <span className={`${baseClassName} ${roundClassName} ${className}`}>
+      {children}
+    </span>
+  );
+};

--- a/beta-reader/src/shared/ui/Tag.tsx
+++ b/beta-reader/src/shared/ui/Tag.tsx
@@ -8,7 +8,7 @@ interface TagProps {
 }
 
 const paddingClassName = "px-3 py-1.5";
-const backgrondClassName = "bg-secondary-700 hover:bg-secondary-500";
+const backgroundClassName = "bg-secondary-700 hover:bg-secondary-500";
 const textClassName = "text-secondary-white text-caption-1-medium";
 
 const baseClassName = `


### PR DESCRIPTION
This pull request introduces several changes to the `beta-reader` project, including updates to the global styles, the addition of a new `CloseIcon` component, and enhancements to the `Tag` component and its Storybook stories.

### Updates to global styles:

* [`beta-reader/app/globals.css`](diffhunk://#diff-f009501aac15fde9d66ce88b4349c8333abb49e49db829d020b1e499d37f5d61L14-R23): Updated secondary color palette to new shades.

### New component addition:

* [`beta-reader/public/assets/CloseIcon.tsx`](diffhunk://#diff-ac7e9c0d834f9f51d5ec1a88fef5bb2897d8ad6e420af54bd83eaad29f4fd0a2R1-R19): Added a new `CloseIcon` component that renders an SVG close icon.
* [`beta-reader/public/assets/index.ts`](diffhunk://#diff-f9a21786063019f9d0f1e2b084b9eef46c4423598ffff830e3b53529b1b246ecR2): Exported the newly added `CloseIcon` component.

### Enhancements to `Tag` component:

* [`beta-reader/src/shared/ui/Tag.tsx`](diffhunk://#diff-be5c779785dd7b2fae91160fe96898f5dc363e46fcebc4916d2121dd2a2d8514R1-R48): Enhanced the `Tag` component to include an optional `CloseIcon` when the `onClick` prop is provided, allowing for clickable tags.

### Storybook stories for `Tag` component:

* [`beta-reader/src/shared/ui/Tag.stories.tsx`](diffhunk://#diff-7cb680a27ae781715c43c5dccec5522b05f75630c5af4f4e18a9de2d0714d2c6R1-R79): Added comprehensive Storybook stories for the `Tag` component, demonstrating various states and configurations.